### PR TITLE
Update bug fix for #26

### DIFF
--- a/sdk/sdk/VKSdk.m
+++ b/sdk/sdk/VKSdk.m
@@ -167,6 +167,7 @@ static NSString * VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_
         }
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:VK_ACCESS_TOKEN_DEFAULTS_KEY];
     [[NSUserDefaults standardUserDefaults] synchronize];
+    vkSdkInstance->_accessToken = nil;
 }
 +(BOOL)wakeUpSession {
     VKAccessToken * token = [VKAccessToken tokenFromDefaults:VK_ACCESS_TOKEN_DEFAULTS_KEY];


### PR DESCRIPTION
Коммит 46f287e не учитывает один момент: 
Поле _accessToken содержит ключ сессии и после вызова forceLogout остается неизменным. Метод getAccessToken продолжает возвращать этот ключ сессии. Любой код получающий ключ через getAccessToken будет выполнятся. Отсутствует возможность проверить текущее состояние (залогинен/разлогинен).
