### PR TITLE
проверка accessToken на nil

### DIFF
--- a/sdk/sdk/VKRequest.m
+++ b/sdk/sdk/VKRequest.m
@@ -154,7 +154,9 @@
 		}
 		VKAccessToken *token = [VKSdk getAccessToken];
 		if (token != nil) {
-			[_preparedParameters setObject:token.accessToken forKey:VK_API_ACCESS_TOKEN];
+            if (token.accessToken != nil) {
+                [_preparedParameters setObject:token.accessToken forKey:VK_API_ACCESS_TOKEN];
+            }
             if (!(self.secure || token.secret) || token.httpsRequired)
                 self.secure = YES;
 		}


### PR DESCRIPTION
Поймал падение на 
[_preparedParameters setObject:token.accessToken forKey:VK_API_ACCESS_TOKEN];
![screenshot on 2014-05-07 at 13-29-49](https://cloud.githubusercontent.com/assets/340680/2900683/70c6c3b6-d5ca-11e3-9e59-1832c6c7ff97.png)
