### PR TITLE
Добавлен метод делегата vkSdkAuthorizationAllowFallbackToSafari

### DIFF
--- a/sdk/sdk/VKSdk.h
+++ b/sdk/sdk/VKSdk.h
@@ -83,6 +83,11 @@
  @param newToken new token for API requests
  */
 - (void)vkSdkRenewedToken:(VKAccessToken *)newToken;
+/**
+ Requests delegate about fallback to Safari during authorization procedure
+ @param fallback If YES, SDK will use Safari when VK app not installed and previous authorization was not succeeded. If NO, SDK will use webView
+ */
+- (BOOL)vkSdkAuthorizationAllowFallbackToSafari;
 
 @end
 

--- a/sdk/sdk/VKSdk.m
+++ b/sdk/sdk/VKSdk.m
@@ -90,6 +90,12 @@ static NSString * VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_
 }
 
 + (void)authorize:(NSArray *)permissions revokeAccess:(BOOL)revokeAccess forceOAuth:(BOOL)forceOAuth {
+	
+	if ([[VKSdk instance].delegate respondsToSelector:@selector(vkSdkAuthorizationAllowFallbackToSafari)]) {
+		if (![[VKSdk instance].delegate vkSdkAuthorizationAllowFallbackToSafari])
+			[VKSdk instance].authState = VKAuthorizationInitialized;
+	}
+	
     //Если не VK app, то необходимо открыть сначала web view
     if ([VKSdk instance].authState == VKAuthorizationInitialized && ![self vkAppMayExists]) {
         [self authorize:permissions revokeAccess:revokeAccess forceOAuth:forceOAuth inApp:YES];


### PR DESCRIPTION
Опциональный метод vkSdkAuthorizationAllowFallbackToSafari протокола
VKSdkDelegate разрешает или запрещает переход на страницу авторизации в
Safari в том случае, если приложение ВКонтакте не установлено в
системе. При запрете перехода SDK использует webView.
