### PR TITLE
Static library recommendation applied.

### DIFF
--- a/sdk/sdk.xcodeproj/project.pbxproj
+++ b/sdk/sdk.xcodeproj/project.pbxproj
@@ -7,6 +7,55 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		132CF7E319D2B3360084884D /* VKApi.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFF3D18241781000BB525 /* VKApi.h */; };
+		132CF7E419D2B3360084884D /* VKRelative.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E7D18D83E0A00DD8B80 /* VKRelative.h */; };
+		132CF7E519D2B3360084884D /* VKApiObject.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E5118D83B5900DD8B80 /* VKApiObject.h */; };
+		132CF7E619D2B3360084884D /* VKApiObjectArray.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E5318D83B5900DD8B80 /* VKApiObjectArray.h */; };
+		132CF7E719D2B3360084884D /* VKAudio.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E5518D83B5900DD8B80 /* VKAudio.h */; };
+		132CF7E819D2B3360084884D /* VKCounters.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E7118D83C9E00DD8B80 /* VKCounters.h */; };
+		132CF7E919D2B3360084884D /* VKLikes.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E5718D83B5900DD8B80 /* VKLikes.h */; };
+		132CF7EA19D2B3360084884D /* VKPhoto.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E5918D83B5900DD8B80 /* VKPhoto.h */; };
+		132CF7EB19D2B3360084884D /* VKSchool.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E7518D83CE200DD8B80 /* VKSchool.h */; };
+		132CF7EC19D2B3360084884D /* VKUniversity.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E7718D83CE200DD8B80 /* VKUniversity.h */; };
+		132CF7ED19D2B3360084884D /* VKUser.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F33F0E5D18D83B5900DD8B80 /* VKUser.h */; };
+		132CF7EE19D2B3360084884D /* VKGroup.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F36114B71976C3830085898F /* VKGroup.h */; };
+		132CF7EF19D2B3360084884D /* VKPhotoSize.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3D751301998AF4100B06DBA /* VKPhotoSize.h */; };
+		132CF7F019D2B3360084884D /* VKApiBase.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFF53182514A9000BB525 /* VKApiBase.h */; };
+		132CF7F119D2B3360084884D /* VKApiPhotos.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3D38E75183D068400D05079 /* VKApiPhotos.h */; };
+		132CF7F219D2B3360084884D /* VKApiWall.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3D38E79183F72F100D05079 /* VKApiWall.h */; };
+		132CF7F319D2B3360084884D /* VKApiUsers.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFF4E182513AA000BB525 /* VKApiUsers.h */; };
+		132CF7F419D2B3360084884D /* VKApiCaptcha.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3A77AD7182A9392006DDF96 /* VKApiCaptcha.h */; };
+		132CF7F519D2B3360084884D /* VKApiFriends.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3B7EEDA1845E80100104B90 /* VKApiFriends.h */; };
+		132CF7F619D2B3360084884D /* VKApiGroups.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F36114BB1976C4C00085898F /* VKApiGroups.h */; };
+		132CF7F719D2B3360084884D /* VKApiConst.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFF5818251EF9000BB525 /* VKApiConst.h */; };
+		132CF7F819D2B3360084884D /* VKApiModels.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F39DB95018868C06009609FB /* VKApiModels.h */; };
+		132CF7F919D2B3360084884D /* VKAuthorizeController.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFB61827C0FF000BB525 /* VKAuthorizeController.h */; };
+		132CF7FA19D2B3360084884D /* VKCaptchaView.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 18680EA81834F23500E532C8 /* VKCaptchaView.h */; };
+		132CF7FB19D2B3360084884D /* VKCaptchaViewController.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3D38E69183CC7C400D05079 /* VKCaptchaViewController.h */; };
+		132CF7FC19D2B3360084884D /* VKShareDialogController.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3611496197674450085898F /* VKShareDialogController.h */; };
+		132CF7FD19D2B3360084884D /* NSError+VKError.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F37846991897AA9300DF860E /* NSError+VKError.h */; };
+		132CF7FE19D2B3360084884D /* VKAccessToken.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3C7549918226ABB00964716 /* VKAccessToken.h */; };
+		132CF7FF19D2B3360084884D /* VKBatchRequest.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3D38E7D183F7B4800D05079 /* VKBatchRequest.h */; };
+		132CF80019D2B3360084884D /* VKBundle.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3BACC5618659493003158DA /* VKBundle.h */; };
+		132CF80119D2B3360084884D /* VKError.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFF3818241779000BB525 /* VKError.h */; };
+		132CF80219D2B3360084884D /* VKHTTPClient.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F311207818588D67004A9A40 /* VKHTTPClient.h */; };
+		132CF80319D2B3360084884D /* VKHTTPOperation.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F311207418588D4E004A9A40 /* VKHTTPOperation.h */; };
+		132CF80419D2B3360084884D /* VKImageParameters.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3AD12951836719B00B837C0 /* VKImageParameters.h */; };
+		132CF80519D2B3360084884D /* VKObject.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFE218294B0A000BB525 /* VKObject.h */; };
+		132CF80619D2B3360084884D /* VKOperation.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3DED12E186C10F500FDF083 /* VKOperation.h */; };
+		132CF80719D2B3360084884D /* VKPermissions.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFA41827B726000BB525 /* VKPermissions.h */; };
+		132CF80819D2B3360084884D /* VKRequest.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3C754901822680D00964716 /* VKRequest.h */; };
+		132CF80919D2B3360084884D /* VKResponse.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3C754931822684500964716 /* VKResponse.h */; };
+		132CF80A19D2B3360084884D /* VKSdkVersion.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFBC1827C582000BB525 /* VKSdkVersion.h */; };
+		132CF80B19D2B3360084884D /* VKUploadPhotoRequest.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3B7EEAC1843721600104B90 /* VKUploadPhotoRequest.h */; };
+		132CF80C19D2B3360084884D /* VKUploadWallPhotoRequest.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3D38E81183FA49000D05079 /* VKUploadWallPhotoRequest.h */; };
+		132CF80D19D2B3360084884D /* VKUploadImage.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F36114AB19768F260085898F /* VKUploadImage.h */; };
+		132CF80E19D2B3360084884D /* VKUploadPhotoBase.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3B7EEDF1845F3D500104B90 /* VKUploadPhotoBase.h */; };
+		132CF80F19D2B3360084884D /* VKUploadMessagesPhotoRequest.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F355BB23199140FC0036AB89 /* VKUploadMessagesPhotoRequest.h */; };
+		132CF81019D2B3360084884D /* VKUtil.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFBB1827C2B6000BB525 /* VKUtil.h */; };
+		132CF81119D2B3360084884D /* NSData+MD5.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFD3182909F3000BB525 /* NSData+MD5.h */; };
+		132CF81219D2B3360084884D /* NSString+MD5.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFD5182909F3000BB525 /* NSString+MD5.h */; };
+		132CF81319D2B3360084884D /* OrderedDictionary.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3EEFFDD1829100C000BB525 /* OrderedDictionary.h */; };
 		183C474718B2F1ED00F978DB /* VKApiBase.m in Sources */ = {isa = PBXBuildFile; fileRef = F3EEFF54182514A9000BB525 /* VKApiBase.m */; };
 		183C474818B2F1ED00F978DB /* VKApiPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = F3D38E76183D068400D05079 /* VKApiPhotos.m */; };
 		183C474918B2F1ED00F978DB /* VKApiWall.m in Sources */ = {isa = PBXBuildFile; fileRef = F3D38E7A183F72F100D05079 /* VKApiWall.m */; };
@@ -34,50 +83,30 @@
 		183C476618B2F1ED00F978DB /* VKUploadPhotoRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = F3B7EEAD1843721600104B90 /* VKUploadPhotoRequest.m */; };
 		183C476718B2F1ED00F978DB /* VKUploadWallPhotoRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = F3D38E82183FA49000D05079 /* VKUploadWallPhotoRequest.m */; };
 		183C476D18B2F1ED00F978DB /* VKSdk.m in Sources */ = {isa = PBXBuildFile; fileRef = F3C75437182133CC00964716 /* VKSdk.m */; };
-		183C476E18B2F1FD00F978DB /* VKUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFFBB1827C2B6000BB525 /* VKUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		183C476F18B2F1FD00F978DB /* VKUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = F349DC531832693000D0DCB3 /* VKUtil.m */; };
 		183C477118B2F1FD00F978DB /* NSData+MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = F3EEFFD4182909F3000BB525 /* NSData+MD5.m */; };
 		183C477218B2F1FD00F978DB /* NSString+MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = F3EEFFD6182909F3000BB525 /* NSString+MD5.m */; };
 		183C477318B2F1FD00F978DB /* OrderedDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = F3EEFFDE1829100C000BB525 /* OrderedDictionary.m */; };
-		18680EAA1834F23500E532C8 /* VKCaptchaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 18680EA81834F23500E532C8 /* VKCaptchaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F311207618588D4E004A9A40 /* VKHTTPOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F311207418588D4E004A9A40 /* VKHTTPOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F311207A18588D67004A9A40 /* VKHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F311207818588D67004A9A40 /* VKHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F33F0E8118D83F3400DD8B80 /* VKApiModels.h in Headers */ = {isa = PBXBuildFile; fileRef = F39DB95018868C06009609FB /* VKApiModels.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F33F0E8218D840DD00DD8B80 /* VKRelative.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E7D18D83E0A00DD8B80 /* VKRelative.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E8318D840DD00DD8B80 /* VKRelative.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E7E18D83E0A00DD8B80 /* VKRelative.m */; };
-		F33F0E8418D840DD00DD8B80 /* VKApiObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E5118D83B5900DD8B80 /* VKApiObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E8518D840DD00DD8B80 /* VKApiObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E5218D83B5900DD8B80 /* VKApiObject.m */; };
-		F33F0E8618D840DD00DD8B80 /* VKApiObjectArray.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E5318D83B5900DD8B80 /* VKApiObjectArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E8718D840DD00DD8B80 /* VKApiObjectArray.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E5418D83B5900DD8B80 /* VKApiObjectArray.m */; };
-		F33F0E8818D840DD00DD8B80 /* VKAudio.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E5518D83B5900DD8B80 /* VKAudio.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E8918D840DD00DD8B80 /* VKAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E5618D83B5900DD8B80 /* VKAudio.m */; };
-		F33F0E8A18D840DD00DD8B80 /* VKCounters.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E7118D83C9E00DD8B80 /* VKCounters.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E8B18D840DD00DD8B80 /* VKCounters.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E7218D83C9E00DD8B80 /* VKCounters.m */; };
-		F33F0E8C18D840DD00DD8B80 /* VKLikes.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E5718D83B5900DD8B80 /* VKLikes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E8D18D840DD00DD8B80 /* VKLikes.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E5818D83B5900DD8B80 /* VKLikes.m */; };
-		F33F0E8E18D840DD00DD8B80 /* VKPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E5918D83B5900DD8B80 /* VKPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E8F18D840DD00DD8B80 /* VKPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E5A18D83B5900DD8B80 /* VKPhoto.m */; };
-		F33F0E9018D840DD00DD8B80 /* VKSchool.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E7518D83CE200DD8B80 /* VKSchool.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E9118D840DD00DD8B80 /* VKSchool.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E7618D83CE200DD8B80 /* VKSchool.m */; };
-		F33F0E9218D840DD00DD8B80 /* VKUniversity.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E7718D83CE200DD8B80 /* VKUniversity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E9318D840DD00DD8B80 /* VKUniversity.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E7818D83CE200DD8B80 /* VKUniversity.m */; };
-		F33F0E9418D840DD00DD8B80 /* VKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = F33F0E5D18D83B5900DD8B80 /* VKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F33F0E9518D840DD00DD8B80 /* VKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = F33F0E5E18D83B5900DD8B80 /* VKUser.m */; };
-		F355BB25199140FC0036AB89 /* VKUploadMessagesPhotoRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F355BB23199140FC0036AB89 /* VKUploadMessagesPhotoRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F355BB26199140FC0036AB89 /* VKUploadMessagesPhotoRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = F355BB24199140FC0036AB89 /* VKUploadMessagesPhotoRequest.m */; };
-		F3611499197674450085898F /* VKShareDialogController.h in Headers */ = {isa = PBXBuildFile; fileRef = F3611496197674450085898F /* VKShareDialogController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F361149A197674450085898F /* VKShareDialogController.m in Sources */ = {isa = PBXBuildFile; fileRef = F3611497197674450085898F /* VKShareDialogController.m */; };
 		F361149B197676870085898F /* VKShareDialogController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F3611498197674450085898F /* VKShareDialogController.xib */; };
 		F36114A9197685810085898F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F36114A4197684870085898F /* Localizable.strings */; };
-		F36114AD19768F260085898F /* VKUploadImage.h in Headers */ = {isa = PBXBuildFile; fileRef = F36114AB19768F260085898F /* VKUploadImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F36114AE19768F260085898F /* VKUploadImage.m in Sources */ = {isa = PBXBuildFile; fileRef = F36114AC19768F260085898F /* VKUploadImage.m */; };
 		F36114B319768FDD0085898F /* vk_settings.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114AF19768FD70085898F /* vk_settings.png */; };
 		F36114B419768FDD0085898F /* vk_settings@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114B019768FD70085898F /* vk_settings@2x.png */; };
 		F36114B519768FDD0085898F /* vk_activity.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114B119768FD70085898F /* vk_activity.png */; };
 		F36114B619768FDD0085898F /* vk_activity@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114B219768FD70085898F /* vk_activity@2x.png */; };
-		F36114B91976C3830085898F /* VKGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = F36114B71976C3830085898F /* VKGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F36114BA1976C3830085898F /* VKGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = F36114B81976C3830085898F /* VKGroup.m */; };
-		F36114BD1976C4C00085898F /* VKApiGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = F36114BB1976C4C00085898F /* VKApiGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F36114BE1976C4C00085898F /* VKApiGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = F36114BC1976C4C00085898F /* VKApiGroups.m */; };
 		F36114C71977DC2D0085898F /* ic_deleteattach.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114C31977DC2D0085898F /* ic_deleteattach.png */; };
 		F36114C81977DC2D0085898F /* ic_deleteattach@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114C41977DC2D0085898F /* ic_deleteattach@2x.png */; };
@@ -85,39 +114,13 @@
 		F36114CA1977DC2D0085898F /* ic_deletephoto@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114C61977DC2D0085898F /* ic_deletephoto@2x.png */; };
 		F36114D11978060F0085898F /* img_newpostattachlink.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114CF1978060F0085898F /* img_newpostattachlink.png */; };
 		F36114D21978060F0085898F /* img_newpostattachlink@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F36114D01978060F0085898F /* img_newpostattachlink@2x.png */; };
-		F378469B1897AA9300DF860E /* NSError+VKError.h in Headers */ = {isa = PBXBuildFile; fileRef = F37846991897AA9300DF860E /* NSError+VKError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3A77AD9182A9392006DDF96 /* VKApiCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A77AD7182A9392006DDF96 /* VKApiCaptcha.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3AD12971836719B00B837C0 /* VKImageParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = F3AD12951836719B00B837C0 /* VKImageParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3B7EEAE1843721600104B90 /* VKUploadPhotoRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F3B7EEAC1843721600104B90 /* VKUploadPhotoRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3B7EEDC1845E80100104B90 /* VKApiFriends.h in Headers */ = {isa = PBXBuildFile; fileRef = F3B7EEDA1845E80100104B90 /* VKApiFriends.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3B7EEE11845F3D500104B90 /* VKUploadPhotoBase.h in Headers */ = {isa = PBXBuildFile; fileRef = F3B7EEDF1845F3D500104B90 /* VKUploadPhotoBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F3BACC481865905B003158DA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F3BACC461865905B003158DA /* InfoPlist.strings */; };
-		F3BACC5818659493003158DA /* VKBundle.h in Headers */ = {isa = PBXBuildFile; fileRef = F3BACC5618659493003158DA /* VKBundle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F3BACC61186883E8003158DA /* ic_vk_logo_nb.png in Resources */ = {isa = PBXBuildFile; fileRef = F3BACC5F186883E8003158DA /* ic_vk_logo_nb.png */; };
 		F3BACC62186883E8003158DA /* ic_vk_logo_nb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F3BACC60186883E8003158DA /* ic_vk_logo_nb@2x.png */; };
 		F3C75431182133CC00964716 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3C75430182133CC00964716 /* Foundation.framework */; };
 		F3C75436182133CC00964716 /* VKSdk.h in Copy Files */ = {isa = PBXBuildFile; fileRef = F3C75435182133CC00964716 /* VKSdk.h */; };
-		F3C755831823BDE800964716 /* VKSdk.h in Headers */ = {isa = PBXBuildFile; fileRef = F3C75435182133CC00964716 /* VKSdk.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3D38E6B183CC7C400D05079 /* VKCaptchaViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D38E69183CC7C400D05079 /* VKCaptchaViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3D38E77183D068400D05079 /* VKApiPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D38E75183D068400D05079 /* VKApiPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3D38E7B183F72F100D05079 /* VKApiWall.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D38E79183F72F100D05079 /* VKApiWall.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3D38E7F183F7B4800D05079 /* VKBatchRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D38E7D183F7B4800D05079 /* VKBatchRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3D38E83183FA49000D05079 /* VKUploadWallPhotoRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D38E81183FA49000D05079 /* VKUploadWallPhotoRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3D751321998AF4100B06DBA /* VKPhotoSize.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D751301998AF4100B06DBA /* VKPhotoSize.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F3D751331998AF4100B06DBA /* VKPhotoSize.m in Sources */ = {isa = PBXBuildFile; fileRef = F3D751311998AF4100B06DBA /* VKPhotoSize.m */; };
-		F3DED130186C10F500FDF083 /* VKOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F3DED12E186C10F500FDF083 /* VKOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFF3A18241779000BB525 /* VKError.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFF3818241779000BB525 /* VKError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFF3F18241781000BB525 /* VKApi.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFF3D18241781000BB525 /* VKApi.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFF50182513AA000BB525 /* VKApiUsers.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFF4E182513AA000BB525 /* VKApiUsers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFF55182514A9000BB525 /* VKApiBase.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFF53182514A9000BB525 /* VKApiBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFF5A18251EF9000BB525 /* VKApiConst.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFF5818251EF9000BB525 /* VKApiConst.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFFA51827B726000BB525 /* VKPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFFA41827B726000BB525 /* VKPermissions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F3EEFFA91827BB18000BB525 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3EEFFA81827BB18000BB525 /* UIKit.framework */; };
-		F3EEFFB81827C0FF000BB525 /* VKAuthorizeController.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFFB61827C0FF000BB525 /* VKAuthorizeController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFFD7182909F3000BB525 /* NSData+MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFFD3182909F3000BB525 /* NSData+MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFFDA182909F3000BB525 /* NSString+MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFFD5182909F3000BB525 /* NSString+MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFFDF1829100C000BB525 /* OrderedDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFFDD1829100C000BB525 /* OrderedDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3EEFFE418294B0A000BB525 /* VKObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEFFE218294B0A000BB525 /* VKObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -137,6 +140,55 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				132CF7E319D2B3360084884D /* VKApi.h in Copy Files */,
+				132CF7E419D2B3360084884D /* VKRelative.h in Copy Files */,
+				132CF7E519D2B3360084884D /* VKApiObject.h in Copy Files */,
+				132CF7E619D2B3360084884D /* VKApiObjectArray.h in Copy Files */,
+				132CF7E719D2B3360084884D /* VKAudio.h in Copy Files */,
+				132CF7E819D2B3360084884D /* VKCounters.h in Copy Files */,
+				132CF7E919D2B3360084884D /* VKLikes.h in Copy Files */,
+				132CF7EA19D2B3360084884D /* VKPhoto.h in Copy Files */,
+				132CF7EB19D2B3360084884D /* VKSchool.h in Copy Files */,
+				132CF7EC19D2B3360084884D /* VKUniversity.h in Copy Files */,
+				132CF7ED19D2B3360084884D /* VKUser.h in Copy Files */,
+				132CF7EE19D2B3360084884D /* VKGroup.h in Copy Files */,
+				132CF7EF19D2B3360084884D /* VKPhotoSize.h in Copy Files */,
+				132CF7F019D2B3360084884D /* VKApiBase.h in Copy Files */,
+				132CF7F119D2B3360084884D /* VKApiPhotos.h in Copy Files */,
+				132CF7F219D2B3360084884D /* VKApiWall.h in Copy Files */,
+				132CF7F319D2B3360084884D /* VKApiUsers.h in Copy Files */,
+				132CF7F419D2B3360084884D /* VKApiCaptcha.h in Copy Files */,
+				132CF7F519D2B3360084884D /* VKApiFriends.h in Copy Files */,
+				132CF7F619D2B3360084884D /* VKApiGroups.h in Copy Files */,
+				132CF7F719D2B3360084884D /* VKApiConst.h in Copy Files */,
+				132CF7F819D2B3360084884D /* VKApiModels.h in Copy Files */,
+				132CF7F919D2B3360084884D /* VKAuthorizeController.h in Copy Files */,
+				132CF7FA19D2B3360084884D /* VKCaptchaView.h in Copy Files */,
+				132CF7FB19D2B3360084884D /* VKCaptchaViewController.h in Copy Files */,
+				132CF7FC19D2B3360084884D /* VKShareDialogController.h in Copy Files */,
+				132CF7FD19D2B3360084884D /* NSError+VKError.h in Copy Files */,
+				132CF7FE19D2B3360084884D /* VKAccessToken.h in Copy Files */,
+				132CF7FF19D2B3360084884D /* VKBatchRequest.h in Copy Files */,
+				132CF80019D2B3360084884D /* VKBundle.h in Copy Files */,
+				132CF80119D2B3360084884D /* VKError.h in Copy Files */,
+				132CF80219D2B3360084884D /* VKHTTPClient.h in Copy Files */,
+				132CF80319D2B3360084884D /* VKHTTPOperation.h in Copy Files */,
+				132CF80419D2B3360084884D /* VKImageParameters.h in Copy Files */,
+				132CF80519D2B3360084884D /* VKObject.h in Copy Files */,
+				132CF80619D2B3360084884D /* VKOperation.h in Copy Files */,
+				132CF80719D2B3360084884D /* VKPermissions.h in Copy Files */,
+				132CF80819D2B3360084884D /* VKRequest.h in Copy Files */,
+				132CF80919D2B3360084884D /* VKResponse.h in Copy Files */,
+				132CF80A19D2B3360084884D /* VKSdkVersion.h in Copy Files */,
+				132CF80B19D2B3360084884D /* VKUploadPhotoRequest.h in Copy Files */,
+				132CF80C19D2B3360084884D /* VKUploadWallPhotoRequest.h in Copy Files */,
+				132CF80D19D2B3360084884D /* VKUploadImage.h in Copy Files */,
+				132CF80E19D2B3360084884D /* VKUploadPhotoBase.h in Copy Files */,
+				132CF80F19D2B3360084884D /* VKUploadMessagesPhotoRequest.h in Copy Files */,
+				132CF81019D2B3360084884D /* VKUtil.h in Copy Files */,
+				132CF81119D2B3360084884D /* NSData+MD5.h in Copy Files */,
+				132CF81219D2B3360084884D /* NSString+MD5.h in Copy Files */,
+				132CF81319D2B3360084884D /* OrderedDictionary.h in Copy Files */,
 				F3C75436182133CC00964716 /* VKSdk.h in Copy Files */,
 			);
 			name = "Copy Files";
@@ -510,62 +562,6 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		F3C755821823BDDE00964716 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F33F0E8C18D840DD00DD8B80 /* VKLikes.h in Headers */,
-				F3B7EEE11845F3D500104B90 /* VKUploadPhotoBase.h in Headers */,
-				F3EEFF5A18251EF9000BB525 /* VKApiConst.h in Headers */,
-				183C476E18B2F1FD00F978DB /* VKUtil.h in Headers */,
-				F33F0E8618D840DD00DD8B80 /* VKApiObjectArray.h in Headers */,
-				F3EEFF3F18241781000BB525 /* VKApi.h in Headers */,
-				F33F0E8A18D840DD00DD8B80 /* VKCounters.h in Headers */,
-				F311207A18588D67004A9A40 /* VKHTTPClient.h in Headers */,
-				F3EEFFE418294B0A000BB525 /* VKObject.h in Headers */,
-				F311207618588D4E004A9A40 /* VKHTTPOperation.h in Headers */,
-				F3EEFFDF1829100C000BB525 /* OrderedDictionary.h in Headers */,
-				18680EAA1834F23500E532C8 /* VKCaptchaView.h in Headers */,
-				F3A77AD9182A9392006DDF96 /* VKApiCaptcha.h in Headers */,
-				F3EEFFA51827B726000BB525 /* VKPermissions.h in Headers */,
-				F33F0E9418D840DD00DD8B80 /* VKUser.h in Headers */,
-				F33F0E8818D840DD00DD8B80 /* VKAudio.h in Headers */,
-				F3D38E77183D068400D05079 /* VKApiPhotos.h in Headers */,
-				F3B7EEDC1845E80100104B90 /* VKApiFriends.h in Headers */,
-				F3EEFF3A18241779000BB525 /* VKError.h in Headers */,
-				F3AD12971836719B00B837C0 /* VKImageParameters.h in Headers */,
-				F33F0E9018D840DD00DD8B80 /* VKSchool.h in Headers */,
-				F3EEFF50182513AA000BB525 /* VKApiUsers.h in Headers */,
-				F36114AD19768F260085898F /* VKUploadImage.h in Headers */,
-				F3D38E7F183F7B4800D05079 /* VKBatchRequest.h in Headers */,
-				F3EEFFDA182909F3000BB525 /* NSString+MD5.h in Headers */,
-				F3EEFFB81827C0FF000BB525 /* VKAuthorizeController.h in Headers */,
-				F3EEFF55182514A9000BB525 /* VKApiBase.h in Headers */,
-				F3DED130186C10F500FDF083 /* VKOperation.h in Headers */,
-				F33F0E8418D840DD00DD8B80 /* VKApiObject.h in Headers */,
-				F33F0E8118D83F3400DD8B80 /* VKApiModels.h in Headers */,
-				F3D38E6B183CC7C400D05079 /* VKCaptchaViewController.h in Headers */,
-				F378469B1897AA9300DF860E /* NSError+VKError.h in Headers */,
-				F3D38E7B183F72F100D05079 /* VKApiWall.h in Headers */,
-				F33F0E8E18D840DD00DD8B80 /* VKPhoto.h in Headers */,
-				F33F0E9218D840DD00DD8B80 /* VKUniversity.h in Headers */,
-				F355BB25199140FC0036AB89 /* VKUploadMessagesPhotoRequest.h in Headers */,
-				F3B7EEAE1843721600104B90 /* VKUploadPhotoRequest.h in Headers */,
-				F33F0E8218D840DD00DD8B80 /* VKRelative.h in Headers */,
-				F3611499197674450085898F /* VKShareDialogController.h in Headers */,
-				F3BACC5818659493003158DA /* VKBundle.h in Headers */,
-				F3EEFFD7182909F3000BB525 /* NSData+MD5.h in Headers */,
-				F3D751321998AF4100B06DBA /* VKPhotoSize.h in Headers */,
-				F36114BD1976C4C00085898F /* VKApiGroups.h in Headers */,
-				F36114B91976C3830085898F /* VKGroup.h in Headers */,
-				F3C755831823BDE800964716 /* VKSdk.h in Headers */,
-				F3D38E83183FA49000D05079 /* VKUploadWallPhotoRequest.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
 		F3BACC3F1865905B003158DA /* VKSdkResources */ = {
 			isa = PBXNativeTarget;
@@ -591,7 +587,6 @@
 				F3C75429182133CC00964716 /* Sources */,
 				F3C7542A182133CC00964716 /* Frameworks */,
 				F3C7542B182133CC00964716 /* Copy Files */,
-				F3C755821823BDDE00964716 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -868,20 +863,11 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DSTROOT = /tmp/sdk.dst;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/..",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/VKSdkWorkspace-avewnfoammyiuxckdllwsbiuivbg/Build/Products/Debug-iphoneos",
-				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = Headers;
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";
@@ -895,19 +881,10 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DSTROOT = /tmp/sdk.dst;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/..",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/VKSdkWorkspace-avewnfoammyiuxckdllwsbiuivbg/Build/Products/Debug-iphoneos",
-				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = Headers;
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";


### PR DESCRIPTION
Project structure edited according this Apple recommendation:
https://developer.apple.com/library/ios/technotes/iOSStaticLibraries/Articles/creating.html#//apple_ref/doc/uid/TP40012554-CH2-SW1
"... If your library target has a “Copy Headers” build phase, you should delete it; copy headers build phases do not work correctly with static library targets when performing the “Archive” action in Xcode.

Next you will add a Copy Files build phase for exporting your headers. ..."

Some unneeded path deleted.
