### PR TITLE
Added support for results of share dialog presenting

### DIFF
--- a/VKSDKTestApplication/VKSDKTestApplication/TestViewController.m
+++ b/VKSDKTestApplication/VKSDKTestApplication/TestViewController.m
@@ -125,6 +125,13 @@ static NSString *const ALL_USER_FIELDS = @"id,first_name,last_name,sex,bdate,cit
         shareDialog.text = @"Your share text here";
         shareDialog.uploadImages = @[[VKUploadImage uploadImageWithImage:[UIImage imageNamed:@"apple"]  andParams:[VKImageParameters jpegImageWithQuality:0.9]]];
         shareDialog.otherAttachmentsStrings = @[@"https://vk.com/dev/ios_sdk"];
+        shareDialog.completionHandler = ^(VKShareDialogControllerResult result){
+            if (result == VKShareDialogControllerResultCancelled){
+                NSLog(@"Share dialog cancelled");
+            }else{
+                NSLog(@"Share dialog done");
+            }
+        };
         [shareDialog presentIn:self];
     }
 }

--- a/sdk/sdk/ShareDialog/VKShareDialogController.h
+++ b/sdk/sdk/ShareDialog/VKShareDialogController.h
@@ -7,6 +7,15 @@
 //
 
 #import <UIKit/UIKit.h>
+
+typedef NS_ENUM(NSInteger, VKShareDialogControllerResult){
+    VKShareDialogControllerResultCancelled,
+    VKShareDialogControllerResultDone
+};
+
+typedef void (^VKShareDialogControllerCompletionHandler) (VKShareDialogControllerResult result);
+
+
 /**
  * Creates dialog for sharing some information from your app to user wall in VK
  */
@@ -22,6 +31,10 @@
 
 /// You can post not only on user wall, but also his friends walls and groups walls
 @property (nonatomic, strong) NSNumber *ownerId;
+
+/// You can receive information about sharing state
+@property (nonatomic, strong) VKShareDialogControllerCompletionHandler completionHandler;
+
 
 /**
  Correctly presents current view controller in another

--- a/sdk/sdk/ShareDialog/VKShareDialogController.m
+++ b/sdk/sdk/ShareDialog/VKShareDialogController.m
@@ -504,6 +504,8 @@ static NSInteger kAttachmentsViewHeight = 90.0f;
 
 -(void) close:(id) sender {
     [self.navigationController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    if (_completionHandler != NULL)
+        _completionHandler(VKShareDialogControllerResultCancelled);
 }
 -(void) sendMessage:(id) sender {
     self.textView.editable  = NO;
@@ -537,6 +539,9 @@ static NSInteger kAttachmentsViewHeight = 90.0f;
     
     [post executeWithResultBlock:^(VKResponse *response) {
         [self.navigationController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+        if (_completionHandler != NULL){
+            _completionHandler(VKShareDialogControllerResultDone);
+        }
     } errorBlock:^(NSError *error) {
         self.navigationItem.rightBarButtonItem  = nil;
         self.navigationItem.rightBarButtonItems = [self rightBarButtonItems];


### PR DESCRIPTION
Several changes in VKShareDialogController. Added support to receive with handler results of user actions.

Works in similar way as SLComposeViewController in Social.Framework.
- You can add to VKShareDialogController block property that will be called after "done" or "close" action
- Type of block is VKShareDialogControllerCompletionHandler
- Block receives only one simple parameter of type VKShareDialogControllerResult
