### PR TITLE
webView -> [urlString hasPrefix] Fix

### DIFF
--- a/sdk/Source/Views/VKAuthorizeController.m
+++ b/sdk/Source/Views/VKAuthorizeController.m
@@ -100,7 +100,7 @@ static NSString *const REDIRECT_URL = @"https://oauth.vk.com/blank.html";
             @"redirect_uri" : redirectUri ?: REDIRECT_URL,
             @"response_type" : @"token"
     };
-    return [NSString stringWithFormat:@"http://oauth.vk.com/authorize?%@", [VKUtil queryStringFromParams:params]];
+    return [NSString stringWithFormat:@"https://oauth.vk.com/authorize?%@", [VKUtil queryStringFromParams:params]];
 }
 
 #pragma mark View prepare


### PR DESCRIPTION
Fix: it seems recently vk.com stopped force redirects from http://oauth.vk.com to httpS://oauth.vk.com. So at the end of workflow [urlString hasPrefix:REDIRECT_URL] will be FALSE, as urlString protocol is not `https`