### PR TITLE
Fixes flow for authorization controller

### DIFF
--- a/VK-ios-sdk.podspec
+++ b/VK-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "VK-ios-sdk"
-  s.version      = "1.1.5"
+  s.version      = "1.1.6"
   s.summary      = "Library for working with VK."
   s.homepage     = "https://vk.com/dev/ios_sdk"
   s.license      = 'MIT'


### PR DESCRIPTION
The controller should be dismissed before access token set because it's impossible to present another view controller from delegate of VkSdk (vkSdkReceivedNewToken:).