### PR TITLE
Fix serialization of permissions when saving access token

### DIFF
--- a/sdk/Source/VKAccessToken.m
+++ b/sdk/Source/VKAccessToken.m
@@ -166,7 +166,7 @@ static NSString *const PERMISSIONS = @"permissions";
             EXPIRES_IN : self.expiresIn ?: @"0",
             USER_ID : self.userId ?: @"0",
             CREATED : @(self.created),
-            PERMISSIONS : self.permissions ?: @""
+            PERMISSIONS : [self.permissions componentsJoinedByString:@","] ?: @""
     } mutableCopy];
 
     if (self.secret) {


### PR DESCRIPTION
В текущем варианте на выходе получалась строка (по крайней мере на iOS 8.3):
````
expires_in=0&permissions=[\n  \"wall\",\n  \"photos\",\n  \"offline\"\n]&user_id=123456&access_token=ACCESS_TOKEN&created=1432238708.587834
````

Собственно, проблема в permissions. Должно быть:
````
expires_in=0&permissions=wall,photos,offline&user_id=123456&access_token=ACCESS_TOKEN&created=1432238708.587834
````

Related to issue #217