### PR TITLE
fix apiObject for enumeration with ignoredProperties

### DIFF
--- a/sdk/Source/API/models/VKApiObject.m
+++ b/sdk/Source/API/models/VKApiObject.m
@@ -195,7 +195,7 @@ static NSString *getPropertyName(objc_property_t prop) {
             objc_property_t property = properties[i];
             VKPropertyHelper *helper = [[VKPropertyHelper alloc] initWith:property];
             if ([ignoredProperties containsObject:helper.propertyName])
-                return;
+                continue;
             if (processBlock)
                 processBlock(helper, propertiesCount);
         }


### PR DESCRIPTION
first ignored field stops enumeration of all other fields