### PR TITLE
Add prefix to DescriptionForObject function to avoid conflicts

### DIFF
--- a/VKSDKTestApplication/VKSDKTestApplication/VKAppDelegate.m
+++ b/VKSDKTestApplication/VKSDKTestApplication/VKAppDelegate.m
@@ -33,4 +33,8 @@
 	return YES;
 }
 
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    [VKSdk handleDidBecomeActive];
+}
+
 @end

--- a/sdk/Source/Utils/OrderedDictionary.m
+++ b/sdk/Source/Utils/OrderedDictionary.m
@@ -23,7 +23,7 @@
 
 #import "OrderedDictionary.h"
 
-NSString *DescriptionForObject(NSObject *object, id locale, NSUInteger indent) {
+NSString *VKDescriptionForObject(NSObject *object, id locale, NSUInteger indent) {
     NSString *objectString;
     if ([object isKindOfClass:[NSString class]]) {
         objectString = (NSString *) object;
@@ -116,8 +116,8 @@ NSString *DescriptionForObject(NSObject *object, id locale, NSUInteger indent) {
     for (NSObject *key in self) {
         [description appendFormat:@"%@    %@ = %@;\n",
                                   indentString,
-                                  DescriptionForObject(key, locale, level),
-                                  DescriptionForObject([self objectForKey:key], locale, level)];
+                                  VKDescriptionForObject(key, locale, level),
+                                  VKDescriptionForObject([self objectForKey:key], locale, level)];
     }
     [description appendFormat:@"%@}\n", indentString];
     return description;

--- a/sdk/Source/VKSdk.h
+++ b/sdk/Source/VKSdk.h
@@ -248,6 +248,11 @@ Checks passed URL for access token
 + (BOOL)processOpenURL:(NSURL *)passedUrl fromApplication:(NSString *)sourceApplication;
 
 /**
+Handle `[AppDelegate applicationDidBecomeActive]` for cases like user starts authorization process but switch back to app without giving access
+*/
++ (void)handleDidBecomeActive;
+
+/**
 * Checks if somebody logged in with SDK
 */
 + (BOOL)isLoggedIn;


### PR DESCRIPTION
При использовании с cocoa pods конфликтует с аналогичной функцией из `VCRURLConnection` в файле `VCROrderedMutableDictionary`.
```
duplicate symbol _DescriptionForObject in:
    /libVCRURLConnection.a(VCROrderedMutableDictionary.o)
    /libVK-ios-sdk.a(OrderedDictionary.o)
ld: 1 duplicate symbol for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Просто изменить тот или другой файл нельзя, так как обе библиотеки добавлены через cocoa pods