### PR TITLE
fix warning when deployment target is 8.0 and higher

### DIFF
--- a/VKSDKTestApplication/VKSDKTestApplication/TestViewController.m
+++ b/VKSDKTestApplication/VKSDKTestApplication/TestViewController.m
@@ -142,7 +142,11 @@ static NSString *const ALL_USER_FIELDS = @"id,first_name,last_name,sex,bdate,cit
                                                             initWithActivityItems:items
                                                             applicationActivities:@[[VKActivity new]]];
         [activityViewController setValue:@"VK SDK" forKey:@"subject"];
+#if  __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+        [activityViewController setCompletionWithItemsHandler:nil];
+#else
         [activityViewController setCompletionHandler:nil];
+#endif
         if (VK_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
             UIPopoverPresentationController *popover = activityViewController.popoverPresentationController;
             popover.sourceView = self.view;

--- a/sdk/Source/Views/VKAuthorizeController.m
+++ b/sdk/Source/Views/VKAuthorizeController.m
@@ -141,7 +141,11 @@
     _webView.scrollView.clipsToBounds = NO;
     [view addSubview:_webView];
     if (self.internalNavigationController) {
+#if  __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:[VKBundle localizedString:@"Cancel"] style:UIBarButtonItemStylePlain target:self action:@selector(cancelAuthorization:)];
+#else
         self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:[VKBundle localizedString:@"Cancel"] style:UIBarButtonItemStyleBordered target:self action:@selector(cancelAuthorization:)];
+#endif
     }
 }
 

--- a/sdk/Source/Views/VKShareDialogController.m
+++ b/sdk/Source/Views/VKShareDialogController.m
@@ -318,7 +318,12 @@ static const CGFloat ipadHeight = 500.f;
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    [self rotateToInterfaceOrientation:self.interfaceOrientation appear:YES];
+#if  __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+    UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
+#else
+    UIInterfaceOrientation orientation = self.interfaceOrientation;
+#endif
+    [self rotateToInterfaceOrientation:orientation appear:YES];
 }
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
@@ -919,7 +924,11 @@ static const CGFloat kAttachmentsViewSize = 100.0f;
     [super viewDidLoad];
     UIImage *image = [VKBundle vkLibraryImageNamed:@"ic_vk_logo_nb"];
     self.navigationItem.titleView = [[UIImageView alloc] initWithImage:image];
+#if  __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:VKLocalizedString(@"Cancel") style:UIBarButtonItemStylePlain target:self action:@selector(close:)];
+#else
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:VKLocalizedString(@"Cancel") style:UIBarButtonItemStyleBordered target:self action:@selector(close:)];
+#endif
     _originalSdkDelegate = [VKSdk instance].delegate;
     [VKSdk instance].delegate = self;
 }


### PR DESCRIPTION
When project deployment target is 8.0 and higher, some warnings occurs. They may be inhibited both manually and with appropriate Podfile config, but it would be much better to use API that is not deprecated.