### PR TITLE
Fix bug - attachments were not shown in VKShareDialogController

### DIFF
--- a/library/Source/Views/VKShareDialogController.m
+++ b/library/Source/Views/VKShareDialogController.m
@@ -1071,6 +1071,7 @@ static const CGFloat kAttachmentsViewSize = 100.0f;
             attach.attachmentString = photo.attachmentString;
             attach.uploadingRequest = nil;
             [self.attachmentsScrollView reloadData];
+            [shareDialogView setNeedsLayout];
         }];
         [uploadRequest setErrorBlock:^(NSError *error) {
             NSLog(@"Error: %@", error.vkError);
@@ -1150,6 +1151,7 @@ static const CGFloat kAttachmentsViewSize = 100.0f;
         [req start];
     }
     [self.attachmentsScrollView reloadData];
+    [shareDialogView setNeedsLayout];
 
     if (self.parent.shareLink) {
         [shareDialogView setShareLink:self.parent.shareLink];


### PR DESCRIPTION
While using this sdk, I encountered a bug when attachments were not shown in the share dialog. Basically, the layout did not trigger an update for creating collection cells when adding images. I tested my app on iOS 9.2.