### PR TITLE
Fixed possibility of garbage value being set.

### DIFF
--- a/library/Source/Views/VKShareDialogController.m
+++ b/library/Source/Views/VKShareDialogController.m
@@ -728,7 +728,7 @@ static const CGFloat kAttachmentsViewSize = 100.0f;
     if (self.notAuthorizedView.superview) {
         self.notAuthorizedView.frame = CGRectMake(0, 0, CGRectGetWidth(self.frame), CGRectGetHeight(self.frame));
         CGSize notAuthorizedTextBoundingSize = CGSizeMake(CGRectGetWidth(self.notAuthorizedView.frame) - 20, CGFLOAT_MAX);
-        CGSize notAuthorizedTextSize;
+        CGSize notAuthorizedTextSize = CGSizeMake(0,0);
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "UnavailableInDeploymentTarget"
         if (VK_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {


### PR DESCRIPTION
A garbage value for the struct can be used unintentionally while initializing self.notAuthorizedLabel.frame a few lines down.

![screen shot 2016-02-29 at 8 03 11 pm](https://cloud.githubusercontent.com/assets/15827184/13415333/80ba9602-df1f-11e5-99b0-11315b30928e.png)

Initializing struct to {0,0} takes care of this issue.