### PR TITLE
Авторизация, восстановление сессии, установка токена, правка api доков, NSCoding моделей

### DIFF
--- a/library/Source/API/VKApi.h
+++ b/library/Source/API/VKApi.h
@@ -69,6 +69,12 @@ Returns object for preparing requests to groups part of API
 + (VKApiGroups *)groups;
 
 /**
+ https://vk.com/dev/docs
+ Returns object for preparing requests to docs part of API
+ */
++ (VKApiDocs *)docs;
+
+/**
 Create new request with parameters. See documentation for methods here https://vk.com/dev/methods
 @param method API-method name, e.g. audio.get
 @param parameters method parameters

--- a/library/Source/API/VKApi.m
+++ b/library/Source/API/VKApi.m
@@ -46,6 +46,10 @@
     return [VKApiGroups new];
 }
 
++ (VKApiDocs *) docs {
+    return [VKApiDocs new];
+}
+
 + (VKRequest *)requestWithMethod:(NSString *)method
                    andParameters:(NSDictionary *)parameters {
     return [VKRequest requestWithMethod:method parameters:parameters];

--- a/library/Source/API/models/VKApiObject.h
+++ b/library/Source/API/models/VKApiObject.h
@@ -46,7 +46,7 @@ Helps in objects parsing
 /**
 Basic class for API objects
 */
-@interface VKApiObject : VKObject <VKApiObject>
+@interface VKApiObject : VKObject <VKApiObject, NSCoding>
 /// If it possible, contains object fields from JSON as it is
 @property(nonatomic, strong) NSDictionary *fields;
 

--- a/library/Source/API/models/VKApiObject.m
+++ b/library/Source/API/models/VKApiObject.m
@@ -36,6 +36,9 @@ static NSString *const DOUBLE_NAME = @"double";
 static NSString *const BOOL_NAME = @"bool";
 static NSString *const ID_NAME = @"id";
 
+
+static NSString *const FIELDS = @"fields";
+
 static NSMutableDictionary *classesProperties = nil;
 
 static NSString *getPropertyType(objc_property_t property) {
@@ -272,6 +275,26 @@ static NSString *getPropertyName(objc_property_t prop) {
     if (PRINT_PARSE_DEBUG_INFO) {
         NSLog(@"Parser tried to set value (%@) for undefined key (%@)", value, key);
     }
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:self.fields forKey:FIELDS];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    NSDictionary* fields = [coder decodeObjectForKey:FIELDS];
+    
+    if (!fields) {
+        return nil;
+    }
+    
+    if (self = [super init]) {
+        [self parse:fields];
+        self.fields = fields;
+    }
+    return self;
 }
 
 @end

--- a/library/Source/API/models/VKDocs.h
+++ b/library/Source/API/models/VKDocs.h
@@ -39,6 +39,7 @@
 @property(nonatomic, copy) NSString *photo_100;
 @property(nonatomic, copy) NSString *photo_130;
 @property(nonatomic, strong) NSNumber *date;
+@property(nonatomic, strong) NSNumber *type;
 @end
 
 /**

--- a/library/Source/VKAccessToken.m
+++ b/library/Source/VKAccessToken.m
@@ -35,6 +35,7 @@ static NSString *const EMAIL = @"email";
 static NSString *const HTTPS_REQUIRED = @"https_required";
 static NSString *const CREATED = @"created";
 static NSString *const PERMISSIONS = @"permissions";
+static NSString *const LOCAL_USER = @"local_user";
 
 @interface VKAccessToken () {
 @protected
@@ -88,6 +89,7 @@ static NSString *const PERMISSIONS = @"permissions";
         _httpsRequired = [aDecoder decodeBoolForKey:HTTPS_REQUIRED];
         _expiresIn = [aDecoder decodeIntegerForKey:EXPIRES_IN];
         _created = [aDecoder decodeDoubleForKey:CREATED];
+        _localUser = [aDecoder decodeObjectForKey:LOCAL_USER];
     }
     return self;
 }
@@ -114,6 +116,7 @@ static NSString *const PERMISSIONS = @"permissions";
     [aCoder encodeBool:self.httpsRequired forKey:HTTPS_REQUIRED];
     [aCoder encodeInteger:self.expiresIn forKey:EXPIRES_IN];
     [aCoder encodeDouble:self.created forKey:CREATED];
+    [aCoder encodeObject:self.localUser forKey: LOCAL_USER];
 }
 
 - (NSArray *)restorePermissions:(NSString *)permissionsString {

--- a/library/Source/VKSdk.h
+++ b/library/Source/VKSdk.h
@@ -44,6 +44,7 @@
 typedef NS_OPTIONS(NSUInteger, VKAuthorizationOptions) {
     VKAuthorizationOptionsUnlimitedToken = 1 << 0,
     VKAuthorizationOptionsDisableSafariController = 1 << 1,
+    VKAuthorizationOptionsDisableApp = 1 << 2,
 };
 
 /**
@@ -200,6 +201,10 @@ Returns token for API requests
 */
 + (VKAccessToken *)accessToken;
 
+/**
+ Sets token for API requests
+ */
++ (void) setAccessToken: (VKAccessToken*) token;
 ///-------------------------------
 /// @name Other methods
 ///-------------------------------
@@ -222,6 +227,7 @@ Checks passed URL for access token
  This method is trying to retrieve token from storage, and check application still permitted to use user access token
  */
 + (void)wakeUpSession:(NSArray *)permissions completeBlock:(void (^)(VKAuthorizationState, NSError *))wakeUpBlock;
++ (void)wakeUpSession:(NSArray *)permissions useInternetToUpdateSession: (BOOL) useInternet completeBlock:(void (^)(VKAuthorizationState, NSError *))wakeUpBlock;
 
 /**
 Forces logout using OAuth (with VKAuthorizeController). Removes all cookies for *.vk.com.

--- a/library/Source/VKSdk.m
+++ b/library/Source/VKSdk.m
@@ -390,6 +390,7 @@ static NSString *VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_D
         if (!useInternet && [instance hasPermissions:permissions]) {
             instance.authState = VKAuthorizationAuthorized;
             wakeUpBlock(instance.authState, nil);
+            return;
         }
         
         instance.authState = VKAuthorizationPending;


### PR DESCRIPTION

**Раз** Сделал возможным принудительно не открывать приложение для авторизации, даже если оно есть. Для этого добавил в перечисление `VKAuthorizationOptions` элемент `VKAuthorizationOptionsDisableApp`.

**Два** Добавил в wakeUpSession параметр для восстановления сессии без интернета.
```objc
+ (void)wakeUpSession:(NSArray *)permissions useInternetToUpdateSession: (BOOL) useInternet completeBlock:(void (^)(VKAuthorizationState, NSError *))wakeUpBlock;
```
Старый метод  работает по прежнему.

**Три** Открыл метод `[VKSdk setAccessToken:]` для ручной установки токена.

**Четыре** Добавил в VKApi доступ к api доков. Добавил в модель доков новое свойство `type`.

**Пять** Все модели имплементят класс NSCoding. Для того, чтобы токен правильно восстанавливался (вместе с localUser), потребовалось, чтобы VKUser имплементил NSCoding. По коду было удобнее сделать это с VKApiObject.