### PR TITLE
fix: Token storage to NSUserDefaults implemented in `save:` in VKAcc…

### DIFF
--- a/library/Source/VKAccessToken.m
+++ b/library/Source/VKAccessToken.m
@@ -170,7 +170,7 @@ static NSString *const PERMISSIONS = @"permissions";
 + (instancetype)savedToken:(NSString *)defaultsKey {
     NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:defaultsKey];
     if (data) {
-        VKAccessToken *token = [self tokenFromUrlString:[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
+        VKAccessToken *token = [NSKeyedUnarchiver unarchiveObjectWithData: data];
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:defaultsKey];
         [[NSUserDefaults standardUserDefaults] synchronize];
         [self save:defaultsKey data:token];
@@ -227,6 +227,7 @@ static NSString *const PERMISSIONS = @"permissions";
 }
 
 + (void)save:(NSString *)service data:(VKAccessToken *)token {
+    [[NSUserDefaults standardUserDefaults] setObject:[NSKeyedArchiver archivedDataWithRootObject:token] forKey:service];
     NSMutableDictionary *keychainQuery = [self getKeychainQuery:service];
     SecItemDelete((__bridge CFDictionaryRef) keychainQuery);
     keychainQuery[(__bridge id) kSecValueData] = [NSKeyedArchiver archivedDataWithRootObject:token];


### PR DESCRIPTION
Token storage to NSUserDefaults implemented in `save:` in VKAccessToken.m, and retrieval from NSUserDefaults fixed in `savedToken:`

This should fix issues #452 and #383 too maybe,
when `SecItemCopyMatching((__bridge CFDictionaryRef) keychainQuery, (CFTypeRef *) &keyData)` returns `nil` when loading token from keychain in projects that use Swift. 