### PR TITLE
Fix missing authentication callback on iOS 10 after user rejects system dialog

### DIFF
--- a/library/Source/VKSdk.m
+++ b/library/Source/VKSdk.m
@@ -178,6 +178,7 @@ static NSString *VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_D
         // to open another app via URL. If user rejects, then no VK SDK callbacks are called.
         // Fixing this using new -[UIApplication openURL:options:completionHandler:] method (iOS 10+).
         
+#ifdef __IPHONE_10_0
         if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
             
             NSDictionary *options = @{ UIApplicationOpenURLOptionUniversalLinksOnly: @NO };
@@ -196,6 +197,9 @@ static NSString *VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_D
         } else {
             [application openURL:urlToOpen];
         }
+#else
+        [application openURL:urlToOpen];
+#endif
     
         instance.authState = VKAuthorizationExternal;
     

--- a/library/Source/VKSdk.m
+++ b/library/Source/VKSdk.m
@@ -174,9 +174,10 @@ static NSString *VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_D
         
         UIApplication *application = [UIApplication sharedApplication];
         
-        // Since iOS 10 there is a dialog asking user if he wants to allow the running app
+        // Since iOS 9 there is a dialog asking user if he wants to allow the running app
         // to open another app via URL. If user rejects, then no VK SDK callbacks are called.
-        // Fixing this using new -[UIApplication openURL:options:completionHandler:] method.
+        // Fixing this using new -[UIApplication openURL:options:completionHandler:] method (iOS 10+).
+        
         if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
             
             NSDictionary *options = @{ UIApplicationOpenURLOptionUniversalLinksOnly: @NO };

--- a/library/Source/VKSdk.m
+++ b/library/Source/VKSdk.m
@@ -178,7 +178,7 @@ static NSString *VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_D
         // to open another app via URL. If user rejects, then no VK SDK callbacks are called.
         // Fixing this using new -[UIApplication openURL:options:completionHandler:] method (iOS 10+).
         
-#ifdef __IPHONE_10_0
+#ifdef __AVAILABILITY_INTERNAL__IPHONE_10_0_DEP__IPHONE_10_0
         if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
             
             NSDictionary *options = @{ UIApplicationOpenURLOptionUniversalLinksOnly: @NO };

--- a/library/Source/VKSdk.m
+++ b/library/Source/VKSdk.m
@@ -171,8 +171,33 @@ static NSString *VK_ACCESS_TOKEN_DEFAULTS_KEY = @"VK_ACCESS_TOKEN_DEFAULTS_KEY_D
     NSURL *urlToOpen = [VKAuthorizeController buildAuthorizationURLWithContext:authContext];
 
     if (vkApp) {
-        [[UIApplication sharedApplication] openURL:urlToOpen];
+        
+        UIApplication *application = [UIApplication sharedApplication];
+        
+        // Since iOS 10 there is a dialog asking user if he wants to allow the running app
+        // to open another app via URL. If user rejects, then no VK SDK callbacks are called.
+        // Fixing this using new -[UIApplication openURL:options:completionHandler:] method.
+        if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+            
+            NSDictionary *options = @{ UIApplicationOpenURLOptionUniversalLinksOnly: @NO };
+            
+            [application openURL:urlToOpen options:options completionHandler:^(BOOL success) {
+                
+                if (!success) {
+                    
+                    VKMutableAuthorizationResult *result = [VKMutableAuthorizationResult new];
+                    result.state = VKAuthorizationError;
+                    result.error = [NSError errorWithVkError:[VKError errorWithCode:VK_API_CANCELED]];
+                    
+                    [[VKSdk instance] notifyDelegate:@selector(vkSdkAccessAuthorizationFinishedWithResult:) obj:result];
+                }
+            }];
+        } else {
+            [application openURL:urlToOpen];
+        }
+    
         instance.authState = VKAuthorizationExternal;
+    
     } else if (safariEnabled && [SFSafariViewController class] && instance.authState < VKAuthorizationSafariInApp) {
         SFSafariViewController *viewController = [[SFSafariViewController alloc] initWithURL:urlToOpen];
         viewController.delegate = instance;


### PR DESCRIPTION
На iOS 10 появился новый системный диалог, спрашивающий у юзера, хочет ли он разрешить приложению открыть приложения VK для авторизации. Если юзер жмет "Отмена", но никаких колбэков от VK SDK не приходит, и если приложение, например, показало лоудер перед началом авторизации, то он никогда не скроется, и приложением невозможно будет дальше пользоваться.