### PR TITLE
Custom UINavigationController subclass for status bar styling

### DIFF
--- a/library/Source/Views/VKAuthorizeController.h
+++ b/library/Source/Views/VKAuthorizeController.h
@@ -30,6 +30,10 @@ typedef NS_ENUM(NSInteger, VKAuthorizationType) {
     VKAuthorizationTypeApp
 };
 
+@interface VKNavigationController : UINavigationController
+
+@end
+
 @interface VKAuthorizationContext : VKObject
 @property (nonatomic, readonly, strong) NSString *clientId;
 @property (nonatomic, readonly, strong) NSString *displayType;

--- a/library/Source/Views/VKAuthorizeController.m
+++ b/library/Source/Views/VKAuthorizeController.m
@@ -37,7 +37,7 @@ NSString *VK_AUTHORIZE_URL_STRING = @"vkauthorize://authorize";
 @property (nonatomic, assign) BOOL usingVkApp;
 @end
 
-@implementation UINavigationController (LastControllerBar)
+@implementation VKNavigationController
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
     if (self.viewControllers.count)
@@ -60,7 +60,7 @@ NSString *VK_AUTHORIZE_URL_STRING = @"vkauthorize://authorize";
 @property(nonatomic, strong) UILabel *statusBar;
 @property(nonatomic, strong) VKError *validationError;
 @property(nonatomic, strong) NSURLRequest *lastRequest;
-@property(nonatomic, weak) UINavigationController *internalNavigationController;
+@property(nonatomic, weak) VKNavigationController *internalNavigationController;
 @property(nonatomic, assign) BOOL finished;
 
 @end
@@ -82,7 +82,7 @@ NSString *VK_AUTHORIZE_URL_STRING = @"vkauthorize://authorize";
 }
 
 + (void)presentThisController:(VKAuthorizeController *)controller {
-    UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:controller];
+    VKNavigationController *navigation = [[VKNavigationController alloc] initWithRootViewController:controller];
 
     if ([VKUtil isOperatingSystemAtLeastIOS7]) {
         navigation.navigationBar.barTintColor = VK_COLOR;


### PR DESCRIPTION
Instead of using a category that affects to all UINavigationController instances across the app, the SDK should use a subclass for custom status bar styling.