### PR TITLE
Add cancel button on ‘error while posting’ alert

### DIFF
--- a/library/Source/Views/VKShareDialogController.m
+++ b/library/Source/Views/VKShareDialogController.m
@@ -1012,6 +1012,8 @@ static const CGFloat kAttachmentsViewSize = 100.0f;
         [[[UIAlertView alloc] initWithTitle:nil message:VKLocalizedString(@"ErrorWhilePosting") delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil] show];
 #else
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil message:VKLocalizedString(@"ErrorWhilePosting") preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
+        [alert addAction:cancelAction];
         [self presentViewController:alert animated:YES completion:nil];
 #endif
     }];


### PR DESCRIPTION
Added the ability to close this alert on iOS 8 and above.