### PR TITLE
Fix retain cycle between VKRequest and VKError

### DIFF
--- a/library/Source/Core/VKRequest.m
+++ b/library/Source/Core/VKRequest.m
@@ -429,6 +429,7 @@ void vksdk_dispatch_on_main_queue_now(void(^block)(void)) {
                 }
             }
         };
+        self.error = nil;
     } else {
         block = ^{
             if (self.completeBlock) {


### PR DESCRIPTION
В методе providerError класса VKRequest вызывается следующий код:

```objective-c
error.vkError.request = self;
self.error = error;
```
Образуется retain cycle, из-за которого в памяти висит VKShareDialogController.
