### PR TITLE
Fix rotation share dialog controller

### DIFF
--- a/library/Source/Views/VKShareDialogController.m
+++ b/library/Source/Views/VKShareDialogController.m
@@ -331,18 +331,24 @@ static const CGFloat ipadHeight = 500.f;
 }
 
 - (BOOL)shouldAutorotate {
-    return YES;
+    return self.parentViewController.shouldAutorotate;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
-    return YES;
+    return [self.parentViewController shouldAutorotateToInterfaceOrientation:toInterfaceOrientation];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
+    if (self.parentViewController) {
+        return [self.parentViewController preferredStatusBarStyle];
+    }
     return UIStatusBarStyleDefault;
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    if (self.parentViewController) {
+        return [self.parentViewController supportedInterfaceOrientations]
+    }
     return UIInterfaceOrientationMaskAll;
 }
 


### PR DESCRIPTION
В текущей версии VKShareDialogController меняет ориентацию, независимо от поведения самого приложения. Из-за этого при смене ориентации во время sharing возникают баги с некорректным поведением приложения.