### PR TITLE
fix UIWebView.delegate not set nil when the delegate is dealloc

### DIFF
--- a/library/Source/Views/VKAuthorizeController.m
+++ b/library/Source/Views/VKAuthorizeController.m
@@ -203,6 +203,10 @@ NSString *VK_AUTHORIZE_URL_STRING = @"vkauthorize://authorize";
     [_webView loadRequest:request];
 }
 
+- (void)dealloc {
+    self.webView.delegate = nil;
+}
+
 #pragma mark Web view work
 
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {


### PR DESCRIPTION
In our app, we got some crash like this
------------------
Application received signal 11  

1   libobjc.A.dylib 0x1800bc150 _objc_msgSend + 16
2   UIKit           0x18799156c -[UIWebView webView:resource:didFinishLoadingFromDataSource:] + 84
3   CoreFoundation  0x18164ce80 ___invoking___ + 144
4   CoreFoundation  0x1815422c4 -[NSInvocation invoke] + 292
5   CoreFoundation  0x181546e9c -[NSInvocation invokeWithTarget:] + 60
6   WebKitLegacy    0x1873d4820 <redacted>
----------------------

Application received signal 11

WebThread

1   libobjc.A.dylib 0x1800bc150 _objc_msgSend + 16
2   UIKit           0x187c33354 -[UIWebView webThreadWebView:resource:willSendRequest:redirectResponse:fromDataSource:] + 92
3   WebKitLegacy    0x187477e60 <redacted>
4   WebKitLegacy    0x1873d315c <redacted>
5   WebCore         0x1861cdee0 WebCore::ResourceLoadNotifier::dispatchWillSendRequest(WebCore::DocumentLoader*, unsigned long, WebCore::ResourceRequest&, WebCore::ResourceResponse const&) + 232
6   WebCore         0x186f1c494 WebCore::ResourceLoader::willSendRequestInternal(WebCore::ResourceRequest&, WebCore::ResourceResponse const&) + 556
7   WebCore         0x18703cbb0 WebCore::SubresourceLoader::willSendRequestInternal(WebCore::ResourceRequest&, WebCore::ResourceResponse const&) + 252
8   WebCore         0x1861cd040 WebCore::ResourceLoader::init(WebCore::ResourceRequest const&) + 288
9   WebCore         0x1861ccdec WebCore::SubresourceLoader::startLoading() + 36
10  WebKitLegacy    0x1874b23b0 <redacted>
---------------


Some blog found out this is because the UIWebView.delegate's property is assign, instead of weak. So, we should set this to nil manually, which is also pointed out in Apple's document:
"Important
Before releasing an instance of UIWebView for which you have set a delegate, you must first set its delegate property to nil. This can be done, for example, in your dealloc method."

![image](https://user-images.githubusercontent.com/12446189/62109554-1b7ae200-b2df-11e9-8bf4-5c078a6143ac.png)
