### PR TITLE
Fix uncaught exception

### DIFF
--- a/library/Source/Views/VKAuthorizeController.m
+++ b/library/Source/Views/VKAuthorizeController.m
@@ -223,8 +223,9 @@ NSString *VK_AUTHORIZE_URL_STRING = @"vkauthorize://authorize";
             }
         }];
         decisionHandler(WKNavigationActionPolicyCancel);
+    } else {
+        decisionHandler(WKNavigationActionPolicyAllow);
     }
-    decisionHandler(WKNavigationActionPolicyAllow);
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {


### PR DESCRIPTION
When using [VKSdk authorize:withOptions:] method with VKAuthorizationOptionsDisableSafariController, when click accept or cancel authorization, the application crashes:
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Completion handler passed to -[VKAuthorizeController webView:decidePolicyForNavigationAction:decisionHandler:] was called more than once'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001079228db __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x0000000106a7cac5 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000107922735 +[NSException raise:format:] + 197
	3   WebKit                              0x000000010870d27f _ZNK6WebKit28CompletionHandlerCallChecker30completionHandlerHasBeenCalledEv + 201
	4   WebKit                              0x0000000108799e87 _ZZN6WebKit15NavigationState16NavigationClient31decidePolicyForNavigationActionERNS_12WebPageProxyEON3WTF3RefIN3API16NavigationActionENS4_13DumbPtrTraitsIS7_EEEEONS5_INS_27WebFramePolicyListenerProxyENS8_ISC_EEEEPNS6_6ObjectEEN3$_4clE24WKNavigationActionPolicyP18_WKWebsitePolicies + 33
	5   App                         0x00000001031f5b7b -[VKAuthorizeController webView:decidePolicyForNavigationAction:decisionHandler:] + 1003
```